### PR TITLE
CALL and RET opcodes are added

### DIFF
--- a/src/tvm.c
+++ b/src/tvm.c
@@ -2,17 +2,12 @@
 #include <tvm/tvm.h>
 
 opcode_t program[] = {
-    {.type = OP_PUSH, .operand.i32 = 1}, 
-    {.type = OP_PUSH, .operand.i32 = 2},  
-    {.type = OP_PUSH, .operand.i32 = 3},
-    {.type = OP_JNZ, .operand.i32 = 11},                 
-    {.type = OP_PUSH, .operand.i32 = 4},
-    {.type = OP_PUSH, .operand.i32 = 5},
-    {.type = OP_PUSH, .operand.i32 = 6},
+    {.type = OP_PUSH, .operand.i32 = 0},
+    {.type = OP_PUSH, .operand.i32 = 1},
+    {.type = OP_CALL, .operand.i32 = 4},
+    {.type = OP_HALT},
     {.type = OP_PUSH, .operand.i32 = 7},
-    {.type = OP_PUSH, .operand.i32 = 8},
-    {.type = OP_PUSH, .operand.i32 = 9},
-    {.type = OP_HALT}                   
+    {.type = OP_RET}
 };
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
First thing, defined a new stack which name is "return_stack" capacity is 1024. That stack stores the instruction point at which position to continue when the function is finished.

Second thing, defined return stack pointer "rsp" for track the "return_stack". Then added them to vm 'constructor' with 0 values.

After that OP_CALL and OP_RET cases added with their body parts.

Finally new test insturctions written in main and tested.